### PR TITLE
feat: add option to generate systemd unit

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,12 +8,15 @@
     {
       "path": "merge",
       "command": "cat",
-      "args": ["%s","-e", "%f"]
+      "args": ["%s", "-e", "%f"]
     },
     {
       "path": "sort",
       "command": "sort",
-      "args": ["-u","%p"]
+      "args": ["-u", "%p"]
     }
-  ]
+  ],
+  "user": "nobody",
+  "jollyexec_location": "/usr/bin/jollyexec",
+  "write_paths": ["/tmp"]
 }

--- a/readme.md
+++ b/readme.md
@@ -31,10 +31,10 @@ So this would be the equivalent of `cat file | rev` being executed on the host. 
 
 The full argument format is:
 
-* %s - pass a file via standard input
-* %f - pass a file via a path
-* %p - pass a generic parameter as a switch (can't have spaces)
-* "raw_string" - pass the exact parameter "raw_string (also can't have spaces)"
+- %s - pass a file via standard input
+- %f - pass a file via a path
+- %p - pass a generic parameter as a switch (can't have spaces)
+- "raw_string" - pass the exact parameter "raw_string (also can't have spaces)"
 
 ## Execution Wrapper
 
@@ -44,9 +44,9 @@ It will take the route name, a variable list of parameters and paths, and constr
 
 It takes the following switches:
 
-* route - what function/command you want to invoke on the jolly executioner
-* -p - pass a parameter value
-* -f - pass a file to be uploaded
+- route - what function/command you want to invoke on the jolly executioner
+- -p - pass a parameter value
+- -f - pass a file to be uploaded
 
 So an example invocation for the above config file would be:
 
@@ -58,7 +58,7 @@ There's no need to use the wrapper if you don't want to, and you can just deal w
 
 The intention is to limit the flexibility of what the client can cause to execute as much as possible. So while it's possible to execute `bash -c` and allow the client to pass whatever it wants as a parameter (i.e. %p), that defeats much of the point. Whenever flexibility is desired, create a new route, and hardcode the required switches, rather than making it variable for the client.
 
-By way of problematic example, let's say you want to reflect a file back to the client using `cat`, but you'd like to have two options, one outputs the file as it would appear, and the other escapes control characters (i.e. the `-e` switch to cat). One could allow a parameter to be submitted by the client where the client could include the `-e` switch or not. However, this would allow *any* input, such that the client could pass in `/etc/passwd` and get the contents of the passwd file. Instead create two different routes one which hardcodes the `-e` switch and the other which hardcodes the `-v` switch.
+By way of problematic example, let's say you want to reflect a file back to the client using `cat`, but you'd like to have two options, one outputs the file as it would appear, and the other escapes control characters (i.e. the `-e` switch to cat). One could allow a parameter to be submitted by the client where the client could include the `-e` switch or not. However, this would allow _any_ input, such that the client could pass in `/etc/passwd` and get the contents of the passwd file. Instead create two different routes one which hardcodes the `-e` switch and the other which hardcodes the `-v` switch.
 
 There's a TODO below about creating a filter for parameters.
 
@@ -99,5 +99,4 @@ Comes from a Rumjacks song https://www.youtube.com/watch?v=sAmgZkPnOS4
 
 ## TODO
 
-* Create a regex filter for parameters to limit what values a client can submit, or at least force someone to consider it.
-* Automatically generate linux sandbox profile based on the execution profile as described by @staaldraad here https://infosec.exchange/@staaldraad/112575264607974109
+- Create a regex filter for parameters to limit what values a client can submit, or at least force someone to consider it.

--- a/systemd_service.tmpl
+++ b/systemd_service.tmpl
@@ -1,0 +1,17 @@
+[Unit]
+Description=jollyexec generated unit
+After=network-online.target
+
+[Service]
+Type=exec
+Restart=on-failure
+User={user}
+ReadOnlyPaths=/
+ReadWritePaths={write_paths}
+ProtectSystem=strict
+NoExecPaths=/
+ExecPaths={exec_paths} /usr/lib /usr/lib64
+ExecStart={jollyexec_location}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Generates a systemd unit file for running jollyexec as a service with sandboxing enabled.

⚠️ notes:
> This is missing a check that paths for executables are fully qualified paths.
This comes with some formatting changes from my editor (Zed), but should conform to rustfmt.

I'm not much of a rust dev, so this probably needs some love