### PR TITLE
misc: workflow permissions update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,27 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
+# default permission at repo level should be read-only
+# be deliberate and precise in ensuring least privilege
+permissions:
+  contents: read
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose


### PR DESCRIPTION
Slight changes to improve the workflow configuration. Doesn't change any behaviour but sets things up for success. The default permission for workflows should be read-only already, but being deliberate and precise doesn't hurt.

* [x] revoke all workflow permissions except read on content
* [x] don't persist credential in git config - no real impact but again, be deliberate about it
 